### PR TITLE
Rust PR #95928 was merged

### DIFF
--- a/_posts/2022-04-12-how-to-speed-up-the-rust-compiler-in-april-2022.md
+++ b/_posts/2022-04-12-how-to-speed-up-the-rust-compiler-in-april-2022.md
@@ -81,7 +81,7 @@ Here are the PRs.
 - [#95794](https://github.com/rust-lang/rust/pull/95794) (3 commits, filed
   April 8): Basic refactorings.
 - [#95928](https://github.com/rust-lang/rust/pull/95928) (5 commits, filed
-  April 11, not yet merged): Avoided some cloning, giving up to 3% wins.
+  April 11): Avoided some cloning, giving up to 3% wins.
 
 Phew! Many thanks to [@petrochenkov](https://github.com/petrochenkov) for
 reviewing all these PRs.


### PR DESCRIPTION
The latest article says that #95928 hasn't been merged, but it has been merged since the time of publication